### PR TITLE
Possible mistake in ingress template

### DIFF
--- a/mlflow/templates/ingress.yaml
+++ b/mlflow/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
               servicePort: {{ default $svcPort .servicePortOverride }}
         {{- end }}
     {{- if .host }}
-      host: {{ .ost | quote }}
+      host: {{ .host | quote }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/mlflow/templates/ingress.yaml
+++ b/mlflow/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
               servicePort: {{ default $svcPort .servicePortOverride }}
         {{- end }}
     {{- if .host }}
-      host: {{ . | quote }}
+      host: {{ .ost | quote }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Changed `.` to `.host` to get this working. Am I using it incorrectly?

The ingress key of `values.yaml` looks like this:
```yaml
ingress:
  enabled: true
  annotations:
    kubernetes.io/ingress.class: traefik
    traefik.frontend.rule.type: PathPrefixStrip
  hosts:
    - host: app.my.host.name.cloud
      paths:
      - path: /mlops/mlflow/
  tls: []
```