### PR TITLE
Fix host value in ingress

### DIFF
--- a/mlflow/templates/ingress.yaml
+++ b/mlflow/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
               servicePort: {{ default $svcPort .servicePortOverride }}
         {{- end }}
     {{- if .host }}
-      host: {{ . | quote }}
+      host: {{ .host | quote }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
When  i try to deploy the chart creating a ingress controler i get an error.

This the ingress block of the values.

```
ingress:
  enabled: true
  annotations:
   kubernetes.io/ingress.class: ....
   ...
  path: /
  hosts:
    - host: mlflow.mydomain
      # ingress.hosts[0].paths -- A list of objects. Each object should contain a `path` key, and may contain a `serviceNameOverride` and a `servicePortOverride` key. If you do not specify any overrides, the Chart will use the ones for the service it creates automatically. We allow overrides to allow advanced behavior like SSL redirection on the AWS ALB Ingress Controller.
      paths:
        - path: "/"
          # serviceNameOverride: chart-example
          # servicePortOverride: 80
  tls:
    - secretName: mlflow
      hosts:
       - mlflow.mydomain
```

i get this error. 

```
Error: UPGRADE FAILED: failed to create resource: Ingress.extensions "mlflow" is invalid: spec.rules[0].host: Invalid value: "map[host:mlflow.mydomain paths:[map[path:/]]]": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```


The `helm template` command print this. 

```
spec:
  tls:
    - hosts:
        - "mlflow.mydomain"
      secretName: mlflow
  rules:
    - http:
        paths:
          - path: "/"
            backend:
              serviceName: mlflow
              servicePort: 5000
      host: "map[host:mlflow.mydomain paths:[map[path:/]]]"
```

The reason is that in the ingress template the host is not correctly defined. This PR will be fix