### PR TITLE
add openshift route

### DIFF
--- a/mlflow/Chart.yaml
+++ b/mlflow/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
   - email: contact@larribas.me
     name: Lorenzo Arribas
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.7.2

--- a/mlflow/README.md
+++ b/mlflow/README.md
@@ -106,6 +106,7 @@ By default, the ingress controller is disabled. You can, however, instruct the C
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| route.enabled | bool | `false` | Creates an OpenShift route object as an alternative to ingress. |
 | securityContext | object | `{}` |  |
 | service.port | int | `5000` |  |
 | service.type | string | `"NodePort"` |  |

--- a/mlflow/templates/route.yaml
+++ b/mlflow/templates/route.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.route.enabled -}}
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ include "mlflow.fullname" . }}
+  labels:
+    {{- include "mlflow.selectorLabels" . | nindent 4 }}
+spec:
+  to:
+    kind: Service
+    name: {{ include "mlflow.fullname" . }}
+    weight: 100
+  port:
+    targetPort: http
+  {{- if .Values.route.tls }}
+  tls:
+    termination: {{ .Values.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/mlflow/values.yaml
+++ b/mlflow/values.yaml
@@ -75,6 +75,12 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+route:
+  enabled: false
+  # tls:
+  #   termination: edge
+  #   insecureEdgeTerminationPolicy: Allow
+
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
Adding an openshift enabled route option to the chart as an alternative to k8s ingress.